### PR TITLE
Options for customizing build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ ENV RTMP_VERSION=1.1.7 \
     NGINX_TEMP_DIR=/var/lib/nginx \
     NGINX_SETUP_DIR=/var/cache/nginx
 
-ARG WITH_RTMP=true \
-  WITH_LOADED_LIBAV=false \
-  WITH_PAGESPEED=true \
-  WITH_DEBUG=false
+ARG WITH_RTMP=true
+ARG WITH_LOADED_LIBAV=false
+ARG WITH_PAGESPEED=true
+ARG WITH_DEBUG=false
 
 COPY setup/ ${NGINX_SETUP_DIR}/
 RUN bash ${NGINX_SETUP_DIR}/install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER sameer@damagehead.com
 
 ENV RTMP_VERSION=1.1.7 \
     NPS_VERSION=1.9.32.10 \
+    LOADED_LIBAV_VERSION=11.4 \
     NGINX_VERSION=1.8.1 \
     NGINX_USER=www-data \
     NGINX_SITECONF_DIR=/etc/nginx/sites-enabled \
@@ -10,9 +11,10 @@ ENV RTMP_VERSION=1.1.7 \
     NGINX_TEMP_DIR=/var/lib/nginx \
     NGINX_SETUP_DIR=/var/cache/nginx
 
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y perl libssl1.0.0 libxslt1.1 libgd3 libxpm4 libgeoip1 libav-tools \
- && rm -rf /var/lib/apt/lists/*
+ARG WITH_RTMP=true \
+  WITH_LOADED_LIBAV=false \
+  WITH_PAGESPEED=true \
+  WITH_DEBUG=false
 
 COPY setup/ ${NGINX_SETUP_DIR}/
 RUN bash ${NGINX_SETUP_DIR}/install.sh

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -29,7 +29,7 @@ APT_PACKAGES="
   gcc g++ make libc6-dev libpcre++-dev libssl-dev libxslt-dev libgd2-xpm-dev
   libgeoip-dev
   perl libssl1.0.0 libxslt1.1 libgd3 libxpm4
-  libgeoip1 libav-tools
+  libgeoip1
 "
 
 CONGIGURE_ARGS="

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -124,8 +124,10 @@ cd ${NGINX_SETUP_DIR}/nginx
 ./configure $CONGIGURE_ARGS
 make && make install
 
-# copy rtmp stats template
-cp ${NGINX_SETUP_DIR}/nginx-rtmp-module/stat.xsl /usr/share/nginx/html/
+$WITH_RTMP && {
+  # copy rtmp stats template
+  cp ${NGINX_SETUP_DIR}/nginx-rtmp-module/stat.xsl /usr/share/nginx/html/
+}
 
 # create default configuration
 mkdir -p /etc/nginx/sites-enabled

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -22,33 +22,106 @@ NGINX_DOWNLOAD_URL="http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"
 NGINX_RTMP_MODULE_DOWNLOAD_URL="https://github.com/arut/nginx-rtmp-module/archive/v${RTMP_VERSION}.tar.gz"
 NGX_PAGESPEED_DOWNLOAD_URL="https://github.com/pagespeed/ngx_pagespeed/archive/v${NPS_VERSION}-beta.tar.gz"
 PSOL_DOWNLOAD_URL="https://dl.google.com/dl/page-speed/psol/${NPS_VERSION}.tar.gz"
+LOADED_LIBAV_URL="https://libav.org/releases/libav-${LOADED_LIBAV_VERSION}.tar.gz"
 
-apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y gcc g++ make libc6-dev libpcre++-dev libssl-dev libxslt-dev libgd2-xpm-dev libgeoip-dev
+LOADED_LIBAV_VERSION=11.4
+APT_PACKAGES="
+  gcc g++ make libc6-dev libpcre++-dev libssl-dev libxslt-dev libgd2-xpm-dev
+  libgeoip-dev
+  perl libssl1.0.0 libxslt1.1 libgd3 libxpm4
+  libgeoip1 libav-tools
+"
+
+CONGIGURE_ARGS="
+  --prefix=/usr/share/nginx
+  --conf-path=/etc/nginx/nginx.conf
+  --sbin-path=/usr/sbin
+  --http-log-path=/var/log/nginx/access.log
+  --error-log-path=/var/log/nginx/error.log
+  --lock-path=/var/lock/nginx.lock
+  --pid-path=/run/nginx.pid
+  --http-client-body-temp-path=${NGINX_TEMP_DIR}/body
+  --http-fastcgi-temp-path=${NGINX_TEMP_DIR}/fastcgi
+  --http-proxy-temp-path=${NGINX_TEMP_DIR}/proxy
+  --http-scgi-temp-path=${NGINX_TEMP_DIR}/scgi
+  --http-uwsgi-temp-path=${NGINX_TEMP_DIR}/uwsgi
+  --with-pcre-jit
+  --with-ipv6
+  --with-http_ssl_module
+  --with-http_stub_status_module
+  --with-http_realip_module
+  --with-http_addition_module
+  --with-http_dav_module
+  --with-http_geoip_module
+  --with-http_gzip_static_module
+  --with-http_image_filter_module
+  --with-http_spdy_module
+  --with-http_sub_module
+  --with-http_xslt_module
+  --with-mail
+  --with-mail_ssl_module
+"
 
 download_and_extract "${NGINX_DOWNLOAD_URL}" "${NGINX_SETUP_DIR}/nginx"
-download_and_extract "${NGINX_RTMP_MODULE_DOWNLOAD_URL}" "${NGINX_SETUP_DIR}/nginx-rtmp-module"
-download_and_extract "${NGX_PAGESPEED_DOWNLOAD_URL}" "${NGINX_SETUP_DIR}/ngx_pagespeed"
-download_and_extract "${PSOL_DOWNLOAD_URL}" "${NGINX_SETUP_DIR}/ngx_pagespeed/psol"
+
+$WITH_RTMP && {
+  download_and_extract "${NGINX_RTMP_MODULE_DOWNLOAD_URL}" \
+    "${NGINX_SETUP_DIR}/nginx-rtmp-module"
+  CONGIGURE_ARGS="$CONGIGURE_ARGS
+    --add-module=${NGINX_SETUP_DIR}/nginx-rtmp-module
+  "
+  $WITH_LOADED_LIBAV && {
+    cat >> /etc/apt/sources.list << EOF
+deb http://archive.ubuntu.com/ubuntu/ trusty multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ trusty multiverse
+EOF
+    download_and_extract "${LOADED_LIBAV_URL}" "${NGINX_SETUP_DIR}/libav"
+
+    APT_PACKAGES="$APT_PACKAGES build-essential yasm libfdk-aac-dev libx264-dev"
+  } || {
+    APT_PACKAGES="$APT_PACKAGES libav-tools"
+  }
+
+}
+
+$WITH_PAGESPEED && {
+  download_and_extract "${NGX_PAGESPEED_DOWNLOAD_URL}" \
+    "${NGINX_SETUP_DIR}/ngx_pagespeed"
+  download_and_extract "${PSOL_DOWNLOAD_URL}"
+    "${NGINX_SETUP_DIR}/ngx_pagespeed/psol"
+  CONGIGURE_ARGS="$CONGIGURE_ARGS
+    --add-module=${NGINX_SETUP_DIR}/ngx_pagespeed
+  "
+}
+
+$WITH_DEBUG && {
+  CONGIGURE_ARGS="$CONGIGURE_ARGS
+    --with-debug
+  "
+}
+
+apt-get update
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y $APT_PACKAGES
+
 
 alias make="make -j$(nproc)"
+
+$WITH_RTMP && WITH_LOADED_LIBAV && {
+  cd ${NGINX_SETUP_DIR}/libav
+  ./configure \
+    --enable-nonfree \
+    --enable-gpl \
+    --disable-shared \
+    --enable-static \
+    --enable-libx264 \
+    --enable-libfdk-aac
+	make && make install
+}
+
+
 cd ${NGINX_SETUP_DIR}/nginx
-./configure --prefix=/usr/share/nginx --conf-path=/etc/nginx/nginx.conf --sbin-path=/usr/sbin \
-  --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log \
-  --lock-path=/var/lock/nginx.lock --pid-path=/run/nginx.pid \
-  --http-client-body-temp-path=${NGINX_TEMP_DIR}/body \
-  --http-fastcgi-temp-path=${NGINX_TEMP_DIR}/fastcgi \
-  --http-proxy-temp-path=${NGINX_TEMP_DIR}/proxy \
-  --http-scgi-temp-path=${NGINX_TEMP_DIR}/scgi \
-  --http-uwsgi-temp-path=${NGINX_TEMP_DIR}/uwsgi \
-  --with-pcre-jit --with-ipv6 --with-http_ssl_module \
-  --with-http_stub_status_module --with-http_realip_module \
-  --with-http_addition_module --with-http_dav_module --with-http_geoip_module \
-  --with-http_gzip_static_module --with-http_image_filter_module \
-  --with-http_spdy_module --with-http_sub_module --with-http_xslt_module \
-  --with-mail --with-mail_ssl_module \
-  --add-module=${NGINX_SETUP_DIR}/nginx-rtmp-module \
-  --add-module=${NGINX_SETUP_DIR}/ngx_pagespeed
+./configure $CONGIGURE_ARGS
 make && make install
 
 # copy rtmp stats template

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -87,7 +87,7 @@ EOF
 $WITH_PAGESPEED && {
   download_and_extract "${NGX_PAGESPEED_DOWNLOAD_URL}" \
     "${NGINX_SETUP_DIR}/ngx_pagespeed"
-  download_and_extract "${PSOL_DOWNLOAD_URL}"
+  download_and_extract "${PSOL_DOWNLOAD_URL}" \
     "${NGINX_SETUP_DIR}/ngx_pagespeed/psol"
   CONGIGURE_ARGS="$CONGIGURE_ARGS
     --add-module=${NGINX_SETUP_DIR}/ngx_pagespeed

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -107,7 +107,7 @@ apt-get install -y $APT_PACKAGES
 
 alias make="make -j$(nproc)"
 
-$WITH_RTMP && WITH_LOADED_LIBAV && {
+$WITH_RTMP && $WITH_LOADED_LIBAV && {
   cd ${NGINX_SETUP_DIR}/libav
   ./configure \
     --enable-nonfree \


### PR DESCRIPTION
Please consider merging this.

While using this Docker setup, I have needed some customizations, and I modified the
Dockerfile and install.sh so that the image building can be customized in a number of
 ways without needing to fork.

Here are the added customizations:

```
--build-arg WITH_DEBUG=true  # Enables building nginx with debug, defaults to false
--build-arg WITH_LOADED_LIBAV=true  # Enables an alternative version of libav,
# that is newer and also supports libfdk-aac, defaults to false
--build-arg WITH_RTMP=false  # Enables the RTMP extension, defaults to true
--build-arg WITH_PAGESPEED=false # Enables Pagespeed, defaults to true
```

Here are some examples:

```

docker build -t docker-nginx .

$ docker run --rm -it docker-nginx nginx -V
Starting nginx...
nginx version: nginx/1.8.1
built by gcc 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)
built with OpenSSL 1.0.1f 6 Jan 2014
TLS SNI support enabled
configure arguments: --prefix=/usr/share/nginx --conf-path=/etc/nginx/nginx.conf
--sbin-path=/usr/sbin --http-log-path=/var/log/nginx/access.log
--error-log-path=/var/log/nginx/error.log --lock-path=/var/lock/nginx.lock
--pid-path=/run/nginx.pid --http-client-body-temp-path=/var/lib/nginx/body
--http-fastcgi-temp-path=/var/lib/nginx/fastcgi --http-proxy-temp-path=/var/lib/nginx/proxy
--http-scgi-temp-path=/var/lib/nginx/scgi --http-uwsgi-temp-path=/var/lib/nginx/uwsgi
 --with-pcre-jit --with-ipv6 --with-http_ssl_module --with-http_stub_status_module
--with-http_realip_module --with-http_addition_module --with-http_dav_module
--with-http_geoip_module --with-http_gzip_static_module --with-http_image_filter_module
--with-http_spdy_module --with-http_sub_module --with-http_xslt_module --with-mail
--with-mail_ssl_module --add-module=/var/cache/nginx/nginx-rtmp-module
--add-module=/var/cache/nginx/ngx_pagespeed


$ docker run --rm -it docker-nginx avconv -version
avconv version 9.18-6:9.18-0ubuntu0.14.04.1, Copyright (c) 2000-2014 the Libav developers
  built on Mar 16 2015 13:19:10 with gcc 4.8 (Ubuntu 4.8.2-19ubuntu1)
avconv 9.18-6:9.18-0ubuntu0.14.04.1
libavutil     52.  3. 0 / 52.  3. 0
libavcodec    54. 35. 0 / 54. 35. 0
libavformat   54. 20. 4 / 54. 20. 4
libavdevice   53.  2. 0 / 53.  2. 0
libavfilter    3.  3. 0 /  3.  3. 0
libavresample  1.  0. 1 /  1.  0. 1
libswscale     2.  1. 1 /  2.  1. 1


$ docker build -t docker-nginx-minimal --build-arg WITH_RTMP=false --build-arg WITH_PAGESPEED=false .

$ docker run --rm -it docker-nginx-minimal nginx -V
Starting nginx...
nginx version: nginx/1.8.1
built by gcc 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)
built with OpenSSL 1.0.1f 6 Jan 2014
TLS SNI support enabled
configure arguments: --prefix=/usr/share/nginx --conf-path=/etc/nginx/nginx.conf
 --sbin-path=/usr/sbin --http-log-path=/var/log/nginx/access.log
--error-log-path=/var/log/nginx/error.log --lock-path=/var/lock/nginx.lock
--pid-path=/run/nginx.pid --http-client-body-temp-path=/var/lib/nginx/body
--http-fastcgi-temp-path=/var/lib/nginx/fastcgi --http-proxy-temp-path=/var/lib/nginx/proxy
--http-scgi-temp-path=/var/lib/nginx/scgi --http-uwsgi-temp-path=/var/lib/nginx/uwsgi
--with-pcre-jit --with-ipv6 --with-http_ssl_module --with-http_stub_status_module
--with-http_realip_module --with-http_addition_module --with-http_dav_module
 --with-http_geoip_module --with-http_gzip_static_module --with-http_image_filter_module
--with-http_spdy_module --with-http_sub_module --with-http_xslt_module
--with-mail --with-mail_ssl_module

$ docker run --rm -it docker-nginx-minimal avconv -version
/sbin/entrypoint.sh: line 38: exec: avconv: not found


$ docker build -t docker-nginx-loaded-streaming-debug --build-arg WITH_DEBUG=true --build-arg WITH_LOADED_LIBAV=true --build-arg WITH_PAGESPEED=false .

$ docker run --rm -it docker-nginx-loaded-streaming-debug nginx -V
Starting nginx...
nginx version: nginx/1.8.1
built by gcc 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)
built with OpenSSL 1.0.1f 6 Jan 2014
TLS SNI support enabled
configure arguments: --prefix=/usr/share/nginx --conf-path=/etc/nginx/nginx.conf
--sbin-path=/usr/sbin --http-log-path=/var/log/nginx/access.log
 --error-log-path=/var/log/nginx/error.log --lock-path=/var/lock/nginx.lock
--pid-path=/run/nginx.pid --http-client-body-temp-path=/var/lib/nginx/body
--http-fastcgi-temp-path=/var/lib/nginx/fastcgi --http-proxy-temp-path=/var/lib/nginx/proxy
 --http-scgi-temp-path=/var/lib/nginx/scgi --http-uwsgi-temp-path=/var/lib/nginx/uwsgi
 --with-pcre-jit --with-ipv6 --with-http_ssl_module --with-http_stub_status_module
--with-http_realip_module --with-http_addition_module --with-http_dav_module
--with-http_geoip_module --with-http_gzip_static_module --with-http_image_filter_module
--with-http_spdy_module --with-http_sub_module --with-http_xslt_module --with-mail
--with-mail_ssl_module --add-module=/var/cache/nginx/nginx-rtmp-module --with-debug


$ docker run --rm -it docker-nginx-loaded-streaming-debug avconv -version
avconv version 11.4, Copyright (c) 2000-2014 the Libav developers
  built on Feb  5 2016 03:38:39 with gcc 4.8 (Ubuntu 4.8.4-2ubuntu1~14.04)
avconv 11.4
libavutil     54.  3. 0 / 54.  3. 0
libavcodec    56.  1. 0 / 56.  1. 0
libavformat   56.  1. 0 / 56.  1. 0
libavdevice   55.  0. 0 / 55.  0. 0
libavfilter    5.  0. 0 /  5.  0. 0
libavresample  2.  1. 0 /  2.  1. 0
libswscale     3.  0. 0 /  3.  0. 0
[daveb@localhost work_dir]$


```
